### PR TITLE
Add verifySignatures option

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -114,6 +114,7 @@ Manager.prototype.save = (function () {
       port: server.port,
       title: server.title,
       von: server.von,
+      verify_signatures: server.verify_signatures,
     });
 
     self.serversHash[server.id] = server;

--- a/lib/server.js
+++ b/lib/server.js
@@ -58,6 +58,7 @@ Server.prototype.update = function (options) {
   this.port = options.port || 2302;
   this.title = options.title;
   this.von = options.von;
+  this.verify_signatures = options.verify_signatures;
 
   this.id = this.generateId();
   this.port = parseInt(this.port, 10); // If port is a string then gamedig fails
@@ -121,6 +122,7 @@ Server.prototype.start = function() {
     players: this.max_players,
     port: this.port,
     serverMods: config.serverMods,
+    verifySignatures: this.verify_signatures ? 2 : 0,
   });
   server.writeServerConfig();
   var instance = server.start();
@@ -256,6 +258,7 @@ Server.prototype.toJSON = function () {
     state: this.state,
     title: this.title,
     von: this.von,
+    verify_signatures: this.verify_signatures,
   };
 };
 

--- a/public/js/app/models/server.js
+++ b/public/js/app/models/server.js
@@ -21,6 +21,7 @@ define(function (require) {
       state: null,
       title: '',
       von: false,
+      verify_signatures: false,
     },
     urlRoot: '/api/servers/',
   });

--- a/public/js/app/views/servers/form.js
+++ b/public/js/app/views/servers/form.js
@@ -29,6 +29,7 @@ define(function (require) {
         port: this.$("form .port").val(),
         title: this.$("form .title").val(),
         von: this.$("form .von").prop("checked"),
+        verify_signatures: this.$("form .verify_signatures").prop("checked"),
       };
     },
 

--- a/public/js/tpl/servers/form.html
+++ b/public/js/tpl/servers/form.html
@@ -84,4 +84,14 @@
       </div>
     </div>
   </div>
+
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-10">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" class="verify_signatures" <% if (verify_signatures) { %>checked="checked"<% } %>> Verify Signatures
+        </label>
+      </div>
+    </div>
+  </div>
 </form>


### PR DESCRIPTION
This should allow people to toggle between verifySignatures 2 and 0. 1 is a valid option, but bohemia says that it's "[outdated and inefficient](https://community.bistudio.com/wiki/server.cfg)".

I haven't worked in your repo much. Hoping master can be merged into feature/steam-workshop-mods. If not, let me know and I can send a separate PR for that.

Thanks and let me know if you want anything changed.