### PR TITLE
Multi-Partition File system issue

### DIFF
--- a/lib/missions.js
+++ b/lib/missions.js
@@ -1,6 +1,6 @@
 var async = require('async');
 var filesize = require('filesize');
-var fs = require('fs');
+var fs = require ('fs.extra');
 var path = require('path');
 var SteamWorkshop = require('steam-workshop');
 
@@ -48,7 +48,7 @@ Missions.prototype.list = function (cb){
 
 Missions.prototype.handleUpload = function (uploadedFile, cb) {
   var filename = decodeURI(uploadedFile.originalname.toLowerCase());
-  fs.rename(uploadedFile.path, path.join(this.missionsPath(), filename), function (err) {
+  fs.move (uploadedFile.path, path.join(this.missionsPath(), filename), function (err) {
     cb(err);
   });
 };


### PR DESCRIPTION
Hey,

I was trying to deploy this repo to a our servers but ran into a bit of an issue when trying to upload files. 

The way our server is setup we attached an SSD drive to our server and mounted it on A:\. We use this drive for everything ARMA related.

When we attempted to upload files, it would fail silently but in the debug the following message would show up:


When we attempted to upload it would fail.
`
 {"errno":-4037,"code":"EXDEV","syscall":"rename","path":"C:\\Windows\\TEMP\\c8bf512af7677d5dbf83a63d5c483c51","dest":"A:\\ARMA-Web\\arma\\mpmissions\\malden_main_operating_base.malden.pbo"}
`  
I changed the rename function to move to fix the issue.

Amazing work by the way, this makes managing ARMA servers so much easier!