### PR TITLE
allow multiple basic auth users, add morgan logFormat config option

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ setupBasicAuth(config, app)
 
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))
-app.use(morgan('dev'))
+app.use(morgan(config.logFormat || 'dev'))
 app.use(serveStatic(path.join(__dirname, 'public')))
 
 var logs = new Logs(config)

--- a/app.js
+++ b/app.js
@@ -19,7 +19,10 @@ setupBasicAuth(config, app)
 
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))
+
+morgan.token('user', function (req) { return req.auth ? req.auth.user : 'anon' })
 app.use(morgan(config.logFormat || 'dev'))
+
 app.use(serveStatic(path.join(__dirname, 'public')))
 
 var logs = new Logs(config)

--- a/app.js
+++ b/app.js
@@ -1,11 +1,11 @@
 var express = require('express')
-var basicAuth = require('express-basic-auth')
 var bodyParser = require('body-parser')
 var morgan = require('morgan')
 var path = require('path')
 var serveStatic = require('serve-static')
 
 var config = require('./config')
+var setupBasicAuth = require('./lib/setup-basic-auth')
 var Manager = require('./lib/manager')
 var Missions = require('./lib/missions')
 var Mods = require('./lib/mods')
@@ -15,14 +15,7 @@ var app = express()
 var server = require('http').Server(app)
 var io = require('socket.io')(server)
 
-if (config.auth && config.auth.username && config.auth.password) {
-  var basicAuthUsers = {}
-  basicAuthUsers[config.auth.username] = config.auth.password
-  app.use(basicAuth({
-    challenge: true,
-    users: basicAuthUsers
-  }))
-}
+setupBasicAuth(config, app)
 
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))

--- a/config.js.example
+++ b/config.js.example
@@ -12,7 +12,7 @@ module.exports = {
     '@mod1',
     '@mod2',
   ],
-  auth: { // If both username and password is set, HTTP Basic Auth will be used
+  auth: { // If both username and password is set, HTTP Basic Auth will be used. You may use an array to specify more than one user.
     username: '', // Username for HTTP Basic Auth
     password: '', // Password for HTTP Basic Auth
   },

--- a/config.js.example
+++ b/config.js.example
@@ -18,4 +18,5 @@ module.exports = {
   },
   prefix: "", // Prefix to all server names
   suffix: "", // Suffix to all server names
+  logFormat: "dev", // expressjs/morgan log format
 };

--- a/lib/setup-basic-auth.js
+++ b/lib/setup-basic-auth.js
@@ -1,0 +1,29 @@
+var basicAuth = require('express-basic-auth')
+
+function getBasicAuthUsers (configAuth) {
+  var basicAuthUsers = {}
+  if (configAuth.username && configAuth.password) {
+    configAuth = [configAuth]
+  }
+
+  configAuth.forEach(function (user) {
+    basicAuthUsers[user.username] = user.password
+  })
+
+  return basicAuthUsers
+}
+
+module.exports = function (config, app) {
+  if (!config.auth) {
+    return
+  }
+
+  if (!config.auth.username && !config.auth.password && !Array.isArray(config.auth)) {
+    return
+  }
+
+  app.use(basicAuth({
+    challenge: true,
+    users: getBasicAuthUsers(config.auth)
+  }))
+}


### PR DESCRIPTION
* allow setting an array of `{username, password}` as `config.auth` allow multiple BasicAuth users
* add `logFormat` config option to specify morgan log format

(motivation: I want to have some level of accountability – having an account for each user & logging username for each API request does that)
