### PR TITLE
add file patching options

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -102,8 +102,10 @@ Manager.prototype.save = function () {
   this.serversArr.forEach(function (server) {
     data.push({
       admin_password: server.admin_password,
+      allowed_file_patching: server.allowed_file_patching,
       auto_start: server.auto_start,
       battle_eye: server.battle_eye,
+      file_patching: server.file_patching,
       forcedDifficulty: server.forcedDifficulty,
       max_players: server.max_players,
       missions: server.missions,

--- a/lib/server.js
+++ b/lib/server.js
@@ -46,8 +46,10 @@ Server.prototype.generateId = function () {
 
 Server.prototype.update = function (options) {
   this.admin_password = options.admin_password
+  this.allowed_file_patching = options.allowed_file_patching
   this.auto_start = options.auto_start
   this.battle_eye = options.battle_eye
+  this.file_patching = options.file_patching
   this.forcedDifficulty = options.forcedDifficulty || null
   this.max_players = options.max_players
   this.missions = options.missions
@@ -112,10 +114,12 @@ Server.prototype.start = function () {
   var parameters = this.getParameters()
   var server = new ArmaServer.Server({
     admins: config.admins,
+    allowedFilePatching: this.allowed_file_patching || 1,
     battleEye: this.battle_eye ? 1 : 0,
     config: this.id,
     disableVoN: this.von ? 0 : 1,
     game: config.game,
+    filePatching: this.file_patching || false,
     forcedDifficulty: this.forcedDifficulty || null,
     headlessClients: this.number_of_headless_clients > 0 ? ['127.0.0.1'] : null,
     hostname: createServerTitle(this.title),
@@ -194,6 +198,7 @@ Server.prototype.startHeadlessClients = function () {
   var self = this
   var headlessClientInstances = _.times(this.number_of_headless_clients, function (i) {
     var headless = new ArmaServer.Headless({
+      filePatching: self.file_patching,
       game: config.game,
       host: '127.0.0.1',
       mods: self.mods,
@@ -272,9 +277,11 @@ Server.prototype.stopHeadlessClients = function () {
 Server.prototype.toJSON = function () {
   return {
     admin_password: this.admin_password,
+    allowed_file_patching: this.allowed_file_patching,
     auto_start: this.auto_start,
     battle_eye: this.battle_eye,
     id: this.id,
+    filePatching: this.file_patching,
     forcedDifficulty: this.forcedDifficulty,
     max_players: this.max_players,
     missions: this.missions,

--- a/public/js/app/models/server.js
+++ b/public/js/app/models/server.js
@@ -9,8 +9,10 @@ define(function (require) {
   return Backbone.Model.extend({
     defaults: {
       admin_password: '',
+      allowed_file_patching: 1,
       auto_start: false,
       battle_eye: false,
+      file_patching: false,
       forcedDifficulty: '',
       max_players: null,
       mods: [],

--- a/public/js/app/views/servers/form.js
+++ b/public/js/app/views/servers/form.js
@@ -20,8 +20,10 @@ define(function (require) {
     serialize : function() {
       return {
         admin_password: this.$("form .admin-password").val(),
+        allowed_file_patching: this.$("form .allowed-file-patching").prop("checked") ? 2 : 1,
         auto_start: this.$("form .auto-start").prop("checked"),
         battle_eye: this.$("form .battle-eye").prop("checked"),
+        file_patching: this.$("form .file-patching").prop("checked"),
         forcedDifficulty: this.$("form .forcedDifficulty").val(),
         max_players: this.$("form .max-players").val(),
         motd: this.$("form .motd").val(),

--- a/public/js/tpl/servers/form.html
+++ b/public/js/tpl/servers/form.html
@@ -60,6 +60,25 @@
   </div>
 
   <div class="form-group">
+    <label class="col-sm-2 control-label">File Patching</label>
+    <div class="col-sm-10">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" class="allowed-file-patching" <% if (allowed_file_patching === 2) { %>checked="checked"<% } %>> Allow file patching for clients
+          <p class="help-block">Required for client userconfigs</p>
+        </label>
+      </div>
+
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" class="file-patching" <% if (file_patching) { %>checked="checked"<% } %>> Use file patching on server
+          <p class="help-block">Required for server userconfigs</p>
+        </label>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
     <label for="headless-clients" class="col-sm-2 control-label">Headless Clients</label>
     <div class="col-sm-10">
       <input type="number" class="form-control headless-clients" data-field="headless-clients" placeholder="Headless Clients" value="<%- number_of_headless_clients %>">


### PR DESCRIPTION
* two checkboxes for server and client that translate into `-filePatching` switch and `allowedFilePatching` config value
* headless clients inherit the configuration from server, so
* `allowedFilePatching` will only ever be 1 and 2 – there's no point in setting it to 0, as the -filePatching switch is is needed for activation anyway.


| desired usage of file patching on… | filePatching |  allowedfilePatching | 
|-------------------|----------------|---------------------------|
| server             | true             |  1     |
| server and client | true        |    2    |
| no-one            | false            | 1 | 
| client | false     |       2        |