### PR TITLE
multi missions file upload

### DIFF
--- a/public/js/tpl/missions/index.html
+++ b/public/js/tpl/missions/index.html
@@ -9,7 +9,7 @@
 
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">Download Mission</h3>
+        <h3 class="panel-title">Download Missions</h3>
       </div>
       <div class="panel-body" id="workshop"></div>
     </div>

--- a/public/js/tpl/missions/upload.html
+++ b/public/js/tpl/missions/upload.html
@@ -1,7 +1,14 @@
 <form class="form" role="form" enctype="multipart/form-data">
   <div class="form-group">
-    <label for="mission" class="control-label">Mission File</label>
-    <input type="file" class="form-control path" name="mission" id="mission" data-field="mission">
+    <label for="missions" class="control-label">Mission Files</label>
+    <input multiple="multiple"
+           accept=".pbo"
+           type="file"
+           class="form-control path"
+           name="missions"
+           id="missions"
+           data-field="missions"
+    >
     <span class="help-block">Only supports missions packed as a PBO</span>
   </div>
   <button type="submit" class="btn btn-primary ladda-button" data-style="expand-left">


### PR DESCRIPTION
well, that was easy.

* add `multiple` attribute in `<input>`
* limit to .pbo files *because I can (tm)* (file picker will let me filter for pbo files. awesome :D )
* receive up to N files on backend side

64 files in one go should be enough for everyone, and prevent one way of accidentally crashing the server.

Fixes #77