### PR TITLE
add start/stop button & player counts to dashboard

### DIFF
--- a/public/js/app/views/servers/list_item.js
+++ b/public/js/app/views/servers/list_item.js
@@ -18,6 +18,8 @@ define(function (require) {
     events: {
       "click .clone": "clone",
       "click .delete": "delete",
+      "click .stop": "stop",
+      "click .start": "start",
     },
 
     modelEvents: {
@@ -44,6 +46,45 @@ define(function (require) {
       function(){
         self.model.destroy();
       });
+    },
+
+
+    start: function (event) {
+      var self = this;
+      event.preventDefault();
+      $.ajax({
+        url: "/api/servers/" + this.model.get('id') + "/start",
+        type: 'POST',
+        success: function (resp) {
+          self.model.set("pid", resp.pid);
+          self.render();
+        },
+        error: $.noop
+      });
+    },
+
+    stop: function (event) {
+      var self = this;
+      event.preventDefault();
+      sweetAlert({
+          title: "Are you sure?",
+          text: "The server will stopped.",
+          type: "warning",
+          showCancelButton: true,
+          confirmButtonClass: "btn-warning",
+          confirmButtonText: "Yes, stop it!",
+        },
+        function(){
+          $.ajax({
+            url: "/api/servers/" + self.model.get('id') + "/stop",
+            type: 'POST',
+            success: function (resp) {
+              self.model.set("pid", resp.pid);
+              self.render();
+            },
+            error: $.noop
+          });
+        });
     },
 
     serverUpdated: function (event) {

--- a/public/js/tpl/servers/list.html
+++ b/public/js/tpl/servers/list.html
@@ -1,7 +1,7 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th>Status</th>
+      <th colspan="2">Status</th>
       <th>Port</th>
       <th>Title</th>
       <th></th>

--- a/public/js/tpl/servers/list_item.html
+++ b/public/js/tpl/servers/list_item.html
@@ -1,13 +1,28 @@
 <td>
   <% if (typeof(pid) != "undefined" && pid) { %>
     <% if (state) { %>
-      <span class="label label-success">Online</span>
+      <span class="label label-success">Online
+      (<%- (state.players) ? state.players.length : '?' %>/<%- state.maxplayers %>)
+      </span>
     <% } else { %>
       <span class="label label-info">Launching</span>
     <% } %>
   <% } else { %>
     <span class="label label-default">Offline</span>
   <% } %>
+</td>
+<td>
+  <% if (typeof(pid) != "undefined" && pid) { %>
+  <button type="button" class="btn btn-info btn-xs stop pull-right">
+    <span class="glyphicon glyphicon-stop"></span> Stop
+  </button>
+  <% } else { %>
+  <button type="button" class="btn btn-info btn-xs start pull-right">
+    <span class="glyphicon glyphicon-play"></span> Start
+  </button>
+  <% } %>
+
+
 </td>
 <td><%-port%></td>
 <td style="width: 100%;">


### PR DESCRIPTION
For us, getting an overview over connected players and starting/stopping servers are the most common uses for the web admin; we'd like to have them on the dashboard.

![screenshot_20171015_222536](https://user-images.githubusercontent.com/52833/31588824-e4b6d312-b1f7-11e7-8b5f-a7ad9cf316b8.png)

![screenshot_20171015_222523](https://user-images.githubusercontent.com/52833/31588825-e80c8f0c-b1f7-11e7-8068-223c98edb0a4.png)

Lots of copy/paste with the start/stop … didnt know how to not do that. :/


ping @Dahlgren 