### PR TITLE
Add support for additional configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ path | Folder path to game server
 port | Web port to use
 host | IP or Hostname to listen on
 type | Which kind of server to use, can be 'linux', 'windows' or 'wine'
+additionalConfigurationOptions | Additional configuration options appended to server.cfg file
 parameters | Extra startup parameters added to servers and headless clients
 serverMods | Mods that always and only will be used by the game servers
 auth | If both username and password is set, HTTP Basic Auth will be used

--- a/config.js.example
+++ b/config.js.example
@@ -4,6 +4,7 @@ module.exports = {
   port: 3000,
   host: '0.0.0.0', // Can be either an IP or a Hostname
   type: 'linux', // Can be either linux, windows or wine
+  additionalConfigurationOptions: '', // Additional configuration options appended to server.cfg file
   parameters: [ // Additional startup parameters used by all servers
     '-noSound',
     '-world=empty'

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -101,6 +101,7 @@ Manager.prototype.save = function () {
   this.serversHash = {}
   this.serversArr.forEach(function (server) {
     data.push({
+      additionalConfigurationOptions: server.additionalConfigurationOptions,
       admin_password: server.admin_password,
       allowed_file_patching: server.allowed_file_patching,
       auto_start: server.auto_start,

--- a/lib/server.js
+++ b/lib/server.js
@@ -45,6 +45,7 @@ Server.prototype.generateId = function () {
 }
 
 Server.prototype.update = function (options) {
+  this.additionalConfigurationOptions = options.additionalConfigurationOptions
   this.admin_password = options.admin_password
   this.allowed_file_patching = options.allowed_file_patching
   this.auto_start = options.auto_start
@@ -110,6 +111,24 @@ Server.prototype.getParameters = function () {
   return parameters
 }
 
+Server.prototype.getAdditionalConfigurationOptions = function () {
+  var additionalConfigurationOptions = ''
+
+  if (config.additionalConfigurationOptions) {
+    additionalConfigurationOptions += config.additionalConfigurationOptions
+  }
+
+  if (this.additionalConfigurationOptions) {
+    if (additionalConfigurationOptions) {
+      additionalConfigurationOptions += '\n'
+    }
+
+    additionalConfigurationOptions += this.additionalConfigurationOptions
+  }
+
+  return additionalConfigurationOptions
+}
+
 Server.prototype.start = function () {
   if (this.instance) {
     return this
@@ -117,6 +136,7 @@ Server.prototype.start = function () {
 
   var parameters = this.getParameters()
   var server = new ArmaServer.Server({
+    additionalConfigurationOptions: this.getAdditionalConfigurationOptions(),
     admins: config.admins,
     allowedFilePatching: this.allowed_file_patching || 1,
     battleEye: this.battle_eye ? 1 : 0,
@@ -280,6 +300,7 @@ Server.prototype.stopHeadlessClients = function () {
 
 Server.prototype.toJSON = function () {
   return {
+    additionalConfigurationOptions: this.additionalConfigurationOptions,
     admin_password: this.admin_password,
     allowed_file_patching: this.allowed_file_patching,
     auto_start: this.auto_start,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "dependencies": {
-    "arma-server": "0.0.6",
+    "arma-server": "0.0.7",
     "async": "^0.9.0",
     "backbone": "1.3.3",
     "backbone.bootstrap-modal": "https://github.com/powmedia/backbone.bootstrap-modal/archive/632210077c2424be2ee6ea2aafe0d3fe016ae524.tar.gz",

--- a/public/js/app/models/server.js
+++ b/public/js/app/models/server.js
@@ -8,6 +8,7 @@ define(function (require) {
 
   return Backbone.Model.extend({
     defaults: {
+      additionalConfigurationOptions: '',
       admin_password: '',
       allowed_file_patching: 1,
       auto_start: false,

--- a/public/js/app/views/servers/form.js
+++ b/public/js/app/views/servers/form.js
@@ -18,6 +18,7 @@ define(function (require) {
 
     serialize : function() {
       return {
+        additionalConfigurationOptions: this.$("form .additional-configuration-options").val(),
         admin_password: this.$("form .admin-password").val(),
         allowed_file_patching: this.$("form .allowed-file-patching").prop("checked") ? 2 : 1,
         auto_start: this.$("form .auto-start").prop("checked"),

--- a/public/js/tpl/servers/form.html
+++ b/public/js/tpl/servers/form.html
@@ -134,4 +134,14 @@
       </div>
     </div>
   </div>
+
+  <div class="form-group">
+    <label for="additional-configuration-options" class="col-sm-2 control-label">Additional configuration options</label>
+    <div class="col-sm-10">
+      <textarea rows="3"
+                class="form-control additional-configuration-options"
+                placeholder="No additional configuration options"><%- additionalConfigurationOptions %></textarea>
+      <p class="help-block">Additional configuration options that will be appended to the generated server.cfg config file. Avoid (re)declaring any of the options above here.</p>
+    </div>
+  </div>
 </form>


### PR DESCRIPTION
Options can be defined globally in config.js or per server in web ui

<img width="1167" alt="Screenshot 2019-05-22 at 16 20 35" src="https://user-images.githubusercontent.com/288631/58182460-ef732d00-7cad-11e9-958e-69f33c6c7975.png">

Fixes #101 and #137 