### PR TITLE
add steam guard code to config

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -18,6 +18,7 @@ module.exports = {
     path: 'path-to-main-steam-folder',
     username: 'steam_username',
     password: 'steam_password',
+    steamGuardCode: 'ABCD3'
   },
   admins: [], // add steam IDs here to enable #login without password
   auth: { // If both username and password is set, HTTP Basic Auth will be used. You may use an array to specify more than one user.

--- a/lib/arma-steam-workshop/acf/path.js
+++ b/lib/arma-steam-workshop/acf/path.js
@@ -1,0 +1,5 @@
+var path = require('path')
+
+module.exports = function (steamDirectory) {
+  return path.join(steamDirectory, 'steamapps', 'workshop', 'appworkshop_107410.acf')
+}

--- a/lib/arma-steam-workshop/acf/read.js
+++ b/lib/arma-steam-workshop/acf/read.js
@@ -1,0 +1,17 @@
+var fs = require('fs')
+var VDF = require('@node-steam/vdf')
+
+var acfPath = require('./path')
+
+module.exports = function (steamDirectory, callback) {
+  var filePath = acfPath(steamDirectory)
+  fs.readFile(filePath, 'utf8', function (err, text) {
+    if (err) {
+      return callback(err)
+    }
+
+    var data = VDF.parse(text)
+
+    return callback(null, data)
+  })
+}

--- a/lib/arma-steam-workshop/acf/write.js
+++ b/lib/arma-steam-workshop/acf/write.js
@@ -1,0 +1,10 @@
+var fs = require('fs')
+var VDF = require('@node-steam/vdf')
+
+var acfPath = require('./path')
+
+module.exports = function (steamDirectory, data, callback) {
+  var filePath = acfPath(steamDirectory)
+  var text = VDF.stringify(data)
+  fs.writeFile(filePath, text, callback)
+}

--- a/lib/arma-steam-workshop/delete_mod.js
+++ b/lib/arma-steam-workshop/delete_mod.js
@@ -1,0 +1,19 @@
+var fs = require('fs.extra')
+var path = require('path')
+var modsDirectory = require('./mods_directory')
+var deleteModFromAcf = require('./delete_mod_from_acf')
+
+module.exports = function (options, callback) {
+  var modsPath = modsDirectory(options.path)
+  var modPath = path.resolve(modsPath, options.workshopId.toString())
+  deleteModFromAcf(options.path, options.workshopId, function (err) {
+    if (err) {
+      if (callback) {
+        callback(err)
+      }
+      return
+    }
+
+    fs.rmrf(modPath, callback)
+  })
+}

--- a/lib/arma-steam-workshop/delete_mod_from_acf.js
+++ b/lib/arma-steam-workshop/delete_mod_from_acf.js
@@ -1,0 +1,13 @@
+var readAcf = require('./acf/read')
+var writeAcf = require('./acf/write')
+var deleteModMetadata = require('./delete_mod_metadata')
+
+module.exports = function (steamDirectory, workshopId, callback) {
+  readAcf(steamDirectory, function (err, data) {
+    if (err) {
+      return callback(err)
+    }
+    deleteModMetadata(data, workshopId)
+    writeAcf(steamDirectory, data, callback)
+  })
+}

--- a/lib/arma-steam-workshop/delete_mod_metadata.js
+++ b/lib/arma-steam-workshop/delete_mod_metadata.js
@@ -1,0 +1,30 @@
+function parseSize (size) {
+  if (size) {
+    return parseInt(size, 10)
+  }
+
+  return null
+}
+
+module.exports = function (data, workshopId) {
+  if (data.AppWorkshop) {
+    var workshop = data.AppWorkshop
+    var sizeOnDisk = parseSize(workshop.SizeOnDisk)
+    var installedItems = workshop.WorkshopItemsInstalled
+
+    if (installedItems && installedItems[workshopId]) {
+      var itemSize = parseSize(installedItems[workshopId].size)
+      delete installedItems[workshopId]
+
+      if (sizeOnDisk && itemSize) {
+        workshop.SizeOnDisk = sizeOnDisk - itemSize
+      }
+    }
+
+    if (workshop.WorkshopItemDetails && workshop.WorkshopItemDetails[workshopId]) {
+      delete workshop.WorkshopItemDetails[workshopId]
+    }
+  }
+
+  return data
+}

--- a/lib/arma-steam-workshop/download_mod.js
+++ b/lib/arma-steam-workshop/download_mod.js
@@ -1,0 +1,12 @@
+var steamcmd = require('steamcmd')
+
+module.exports = function (options, callback) {
+  steamcmd.install({
+    applicationId: 107410,
+    path: options.path,
+    password: options.password,
+    username: options.username,
+    steamGuardCode: options.steamGuardCode,
+    workshopId: options.workshopId
+  }, callback)
+}

--- a/lib/arma-steam-workshop/index.js
+++ b/lib/arma-steam-workshop/index.js
@@ -1,0 +1,49 @@
+var deleteMod = require('./delete_mod')
+var downloadMod = require('./download_mod')
+var mods = require('./mods')
+var search = require('./search')
+
+var SteamWorkshop = function (options) {
+  this.currentDownloads = {}
+  this.options = options
+}
+
+SteamWorkshop.prototype.mods = function (callback) {
+  mods(this.options.path, this.currentDownloads, callback)
+}
+
+SteamWorkshop.prototype.deleteMod = function (workshopId, callback) {
+  deleteMod({
+    workshopId: workshopId,
+    path: this.options.path
+  }, callback)
+}
+
+SteamWorkshop.prototype.downloadMod = function (workshopId, callback) {
+  if (this.currentDownloads[workshopId]) {
+    return callback(new Error('Already downloading ' + workshopId))
+  }
+
+  var self = this
+  self.currentDownloads[workshopId] = true
+
+  downloadMod({
+    workshopId: workshopId,
+    path: this.options.path,
+    username: this.options.username,
+    password: this.options.password,
+    steamGuardCode: this.options.steamGuardCode
+  }, function (err) {
+    delete self.currentDownloads[workshopId]
+
+    if (callback) {
+      return callback(err)
+    }
+  })
+}
+
+SteamWorkshop.prototype.search = function (text, callback) {
+  search(text, this.options.apiKey, callback)
+}
+
+module.exports = SteamWorkshop

--- a/lib/arma-steam-workshop/mods.js
+++ b/lib/arma-steam-workshop/mods.js
@@ -1,0 +1,85 @@
+var async = require('async')
+var path = require('path')
+
+var readAcf = require('./acf/read')
+var SteamWorkshop = require('steam-workshop')
+
+var steamWorkshop = new SteamWorkshop()
+
+function fetchMods (ids, callback) {
+  steamWorkshop.getPublishedFileDetails(ids, callback)
+}
+
+function getModsFromACF (acf) {
+  var mods = {}
+
+  var installed = acf.AppWorkshop.WorkshopItemsInstalled
+  var details = acf.AppWorkshop.WorkshopItemDetails
+
+  for (var id in installed) {
+    mods[id] = installed[id]
+  }
+
+  for (var id in details) {
+    mods[id] = details[id]
+  }
+
+  return mods
+}
+
+module.exports = function (steamDirectory, currentDownloads, callback) {
+  readAcf(steamDirectory, function (err, acf) {
+    if (err) {
+      return callback(err)
+    }
+
+    var acfMods = getModsFromACF(acf)
+    var ids = Object.keys(acfMods)
+
+    Object.keys(currentDownloads).forEach(function (id) {
+      if (ids.indexOf(id) === -1) {
+        ids.push(id)
+      }
+    })
+
+    fetchMods(ids, function (err, mods) {
+      if (err) {
+        return callback(err)
+      }
+
+      callback(null, mods.map(function (mod) {
+        if (!mod) {
+          return
+        }
+
+        var id = mod.publishedfileid
+        var downloading = currentDownloads[id] === true
+        var folder = path.join(steamDirectory, 'steamapps', 'workshop', 'content', '107410', id)
+        var title = mod.title
+
+        var acfMod = acfMods[id]
+        var partial = false
+        var outdated = false
+
+        if (acfMod) {
+          partial = acfMod.BytesToDownload > 0
+          outdated = mod.time_updated > acfMod.timeupdated
+        }
+
+        var needsUpdate = downloading || outdated || partial
+
+        return {
+          downloading: downloading,
+          id: id,
+          name: title || id,
+          needsUpdate: needsUpdate,
+          path: folder
+        }
+      }).filter(function (mod) {
+        return mod && mod.id && mod.name && mod.path
+      }).sort(function (a, b) {
+        return a.name.localeCompare(b.name)
+      }))
+    })
+  })
+}

--- a/lib/arma-steam-workshop/mods_directory.js
+++ b/lib/arma-steam-workshop/mods_directory.js
@@ -1,0 +1,5 @@
+var path = require('path')
+
+module.exports = function (steamDirectory) {
+  return path.join(steamDirectory, 'steamapps', 'workshop', 'content', '107410')
+}

--- a/lib/arma-steam-workshop/search.js
+++ b/lib/arma-steam-workshop/search.js
@@ -1,0 +1,50 @@
+var filesize = require('filesize')
+var SteamWorkshop = require('steam-workshop')
+var steamWorkshop = new SteamWorkshop()
+
+const BASE_URL = 'https://steamcommunity.com/sharedfiles/filedetails/'
+
+function formatItem (item) {
+  return {
+    created: item.created,
+    description: item.short_description,
+    fileSize: item.file_size,
+    fileSizeFormatted: item.file_size ? filesize(item.file_size) : undefined,
+    id: item.publishedfileid,
+    image: item.preview_url,
+    link: BASE_URL + item.publishedfileid,
+    subscriptions: item.subscriptions,
+    title: item.title,
+    updated: item.updated
+  }
+}
+
+function createQuery (text, apiKey) {
+  return {
+    appid: 107410,
+    key: apiKey,
+    numperpage: 100,
+    return_metadata: 1,
+    return_short_description: 1,
+    search_text: text
+  }
+}
+
+module.exports = function (text, apiKey, callback) {
+  if (!text) {
+    return callback(new Error('Missing text parameter'))
+  }
+
+  steamWorkshop.queryFiles(createQuery(text, apiKey), function (err, mods) {
+    if (err) {
+      return callback(err)
+    }
+
+    // Remove missions from result, missions contains a filename, mods don't
+    mods = mods.filter(function (item) {
+      return item.result === 1 && !item.filename
+    })
+
+    return callback(null, mods.map(formatItem))
+  })
+}

--- a/lib/steam_mods.js
+++ b/lib/steam_mods.js
@@ -1,5 +1,5 @@
 var events = require('events')
-var ArmaSteamWorkshop = require('arma-steam-workshop')
+var ArmaSteamWorkshop = require('./arma-steam-workshop')
 
 var SteamMods = function (config) {
   this.config = config

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     ]
   },
   "dependencies": {
+    "@node-steam/vdf": "^2.0.1",
+    "arma-class-parser": "^0.1.3",
     "arma-server": "0.0.7",
-    "arma-steam-workshop": "https://github.com/Dahlgren/node-arma-steam-workshop/tarball/57f11ee85ccac0a18a74c5acb5645c9af78ec5c0",
     "async": "^0.9.0",
     "backbone": "1.3.3",
     "backbone.bootstrap-modal": "https://github.com/powmedia/backbone.bootstrap-modal/archive/632210077c2424be2ee6ea2aafe0d3fe016ae524.tar.gz",
@@ -44,6 +45,7 @@
     "slugify": "^1.1.0",
     "socket.io": "2.1.1",
     "steam-workshop": "0.0.4",
+    "steamcmd": "https://github.com/Dahlgren/node-steamcmd/tarball/22abda41abc014006204fdb2b94951049fb20bba",
     "style-loader": "0.13.1",
     "sweetalert": "^1.1.3",
     "underscore": "^1.9.1",


### PR DESCRIPTION
In order to be able to use the steam guard code in config, it was necessary to get rid of the dependency to the 'arma-steam-workshop' library and move into the project, making changes here.