### PR TITLE
add `config.logStream`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ port | Web port to use
 host | IP or Hostname to listen on
 type | Which kind of server to use, can be 'linux', 'windows' or 'wine'
 additionalConfigurationOptions | Additional configuration options appended to server.cfg file
+logFormat | ExpressJS/Morgan log format, defaults to `"dev"`
+logStream | ExpressJS/Morgan writable log stream, defaults to `process.stdout`
 parameters | Extra startup parameters added to servers and headless clients
 serverMods | Mods that always and only will be used by the game servers
 auth | If both username and password is set, HTTP Basic Auth will be used

--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))
 
 morgan.token('user', function (req) { return req.auth ? req.auth.user : 'anon' })
-app.use(morgan(config.logFormat || 'dev'))
+app.use(morgan(config.logFormat || 'dev', { stream: config.logStream || process.stdout }))
 
 app.use(serveStatic(path.join(__dirname, 'public')))
 


### PR DESCRIPTION
... and document both logStream and logFormat options

Due to unhappy circumstances 🙄 I'm running arma-server-web-admin as a service on Windows Server, which makes `process.stdout` unaccessible to me. Making the stream configurable gives me the possbility to create a writable file stream in config.js

* Pro: this is a minimal change to the codebase
* Con: it's not particularly convenient for users who do not have a NodeJS background