### PR TITLE
fix #218 and prevent usage of brackets in server name

### DIFF
--- a/public/js/tpl/servers/form.html
+++ b/public/js/tpl/servers/form.html
@@ -2,7 +2,7 @@
   <div class="form-group">
     <label for="title" class="col-sm-2 control-label">Title</label>
     <div class="col-sm-10">
-      <input type="text" class="form-control title" placeholder="Title" value="<%- title %>">
+      <input type="text" class="form-control title" placeholder="Title - no brackets allowed!" value="<%- title %>" pattern="[^\[\]]+">
     </div>
   </div>
 


### PR DESCRIPTION
as server name is used for config file name, some characterrs break things. like brackets. bad. dont use brackets.

see also #218


(is this the only server form?)