### PR TITLE
enabled SSL for the webserver

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,11 @@ var Logs = require('./lib/logs')
 var Settings = require('./lib/settings')
 
 var app = express()
-var server = require('http').Server(app)
+var fs = require('fs');
+var privateKey  = fs.readFileSync('ssl.key', 'utf8');
+var certificate = fs.readFileSync('ssl.crt', 'utf8');
+var credentials = {key: privateKey, cert: certificate};
+var server = require('https').Server(credentials, app)
 var io = require('socket.io')(server)
 
 setupBasicAuth(config, app)


### PR DESCRIPTION
This is a quick demo how to enable SSL on the webserver. Seems to work pretty well.
I created cert & key using
`openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ssl.key -out ssl.crt`
but you also can use LetsEncrypt or other certificates.