### PR TITLE
Add 'modsPath' optional setting

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,14 @@ var webpack = require('webpack')
 var webpackMiddleware = require('webpack-dev-middleware')
 
 var config = require('./config')
+
+if( !config.modsPath
+  || typeof config.modsPath !== 'string'
+  || config.modsPath.length < 1)
+{
+  config.modsPath = config.path
+}
+
 var webpackConfig = require('./webpack.config')
 var setupBasicAuth = require('./lib/setup-basic-auth')
 var Manager = require('./lib/manager')

--- a/config.js.example
+++ b/config.js.example
@@ -1,6 +1,7 @@
 module.exports = {
   game: 'arma3', // arma3, arma2oa, arma2, arma1, cwa, ofpresistance, ofp
   path: 'path-to-arma3-directory',
+  //modsPath: 'optional-path-to-mods-directory-that-defaults-to-PATH-to-arma3-directory-if-empty-or-undefined',
   port: 3000,
   host: '0.0.0.0', // Can be either an IP or a Hostname
   type: 'linux', // Can be either linux, windows or wine

--- a/lib/mods/index.js
+++ b/lib/mods/index.js
@@ -29,7 +29,7 @@ Mods.prototype.delete = function (mod, cb) {
 
 Mods.prototype.updateMods = function () {
   var self = this
-  glob('**/{@*,csla,gm,spe,vn,ws}/addons', { cwd: self.config.path }, function (err, files) {
+  glob('**/{@*,csla,gm,spe,vn,ws}/addons', { cwd: self.config.modsPath }, function (err, files) {
     if (err) {
       console.log(err)
       return

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -5,7 +5,7 @@ var Settings = function (config) {
 }
 
 Settings.prototype.getPublicSettings = function () {
-  return _.pick(this.config, ['game', 'path', 'type'])
+  return _.pick(this.config, ['game', 'path', 'modsPath', 'type'])
 }
 
 module.exports = Settings

--- a/public/js/app/models/settings.js
+++ b/public/js/app/models/settings.js
@@ -3,6 +3,7 @@ var Backbone = require('backbone')
 module.exports = Backbone.Model.extend({
   defaults: {
     path: '',
+    modsPath: '',
     type: ''
   },
   urlRoot: '/api/settings'

--- a/public/js/tpl/settings.html
+++ b/public/js/tpl/settings.html
@@ -5,6 +5,12 @@
       <input type="text" class="form-control" placeholder="Path to ArmA" disabled value="<%- path %>">
     </div>
   </div>
+  <div class="form-group">
+    <label for="mods" class="col-sm-2 control-label">Mods folder</label>
+    <div class="col-sm-10">
+      <input type="text" class="form-control" placeholder="Mods folder" disabled value="<%- modsPath %>">
+    </div>
+  </div>
 
   <div class="form-group">
     <label for="type" class="col-sm-2 control-label">Type</label>


### PR DESCRIPTION
Currently, the default behavior of the application looks for mod files exclusively inside the Game folder path, by using the value inside config.path. With this commit I add an optional setting inside 'config.js', named .modsPath, which allows you to set a different path to your mods folder.

With the value of .modsPath set to a valid folder, the application will look for your mod files exclusively inside that alternative route.

In order to preserve compatibility with the previous behavior, if the config.modsPath value is empty of undefine inside the 'config.js' file, config.modsPath value will default to the value of config.path (the path to your ArmA3 folder).